### PR TITLE
Add Docker customization for RobCo terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends figlet && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY robco_theme.sh /etc/profile.d/robco_theme.sh
+
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY robco_theme.sh /etc/profile.d/robco_theme.sh
+# Ensure Unix line endings in case the file was created on Windows
+RUN sed -i 's/\r$//' /etc/profile.d/robco_theme.sh
 
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# robco
+# RobCo Terminal Docker Image
+
+This repository contains a sample Docker setup that mimics the RobCo terminal from Fallout 4.
+
+## Build the Image
+
+```bash
+docker build -t robco .
+```
+
+## Run the Container
+
+```bash
+docker run --rm -it robco
+```
+
+The container shows a RobCo-style banner and sets a green prompt when you start an interactive shell.

--- a/robco_theme.sh
+++ b/robco_theme.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Display RobCo-style banner on interactive shells
+if [ -n "$PS1" ]; then
+    clear
+    figlet -c "ROBCO INDUSTRIES"
+fi
+
+# Green-on-black style prompt
+export PS1="\[\e[0;32m\][\u@ROBCO \W]\\$ \[\e[0m\]"
+

--- a/robco_theme.sh
+++ b/robco_theme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Display RobCo-style banner on interactive shells
 if [ -n "$PS1" ]; then
@@ -7,5 +7,5 @@ if [ -n "$PS1" ]; then
 fi
 
 # Green-on-black style prompt
-export PS1="\[\e[0;32m\][\u@ROBCO \W]\\$ \[\e[0m\]"
+export PS1="\[\e[0;32m\][\u@ROBCO \W]\$ \[\e[0m\]"
 


### PR DESCRIPTION
## Summary
- add Dockerfile that installs figlet and uses custom profile script
- implement `robco_theme.sh` to show RobCo banner and green prompt
- update README with build and run instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e2f538e5483338f1f3fc28146ae2d